### PR TITLE
adding python notebook for dalle bot

### DIFF
--- a/DALLE/Dalle_Python.ipynb
+++ b/DALLE/Dalle_Python.ipynb
@@ -1,0 +1,458 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "83c48f12-74de-4ff5-9d38-e82c59d2e98e",
+   "metadata": {},
+   "source": [
+    "## Objective : Create a dall-e bot to convert prompts to images using DALL-E\n",
+    "\n",
+    "### Use the DALL-E library in combination with the openai api to convert your prompts into images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "333a0d06-fead-4f8d-ac59-39423b62d7ff",
+   "metadata": {},
+   "source": [
+    "So we start by installing the openai library, who owns the dall-e library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7a162917-6be3-4716-b8ea-c89730630a41",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:05:49.948424Z",
+     "iopub.status.busy": "2023-02-24T07:05:49.948158Z",
+     "iopub.status.idle": "2023-02-24T07:05:49.951527Z",
+     "shell.execute_reply": "2023-02-24T07:05:49.951146Z",
+     "shell.execute_reply.started": "2023-02-24T07:05:49.948375Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# !pip install openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e8cca2c-fd1a-4997-86cc-8f870e6d9dc4",
+   "metadata": {},
+   "source": [
+    "I would definitely suggest checking out the functionality of openai. ( Hint : It's quite good ) \n",
+    "\n",
+    "https://platform.openai.com/docs/api-reference?lang=pythonhttps://platform.openai.com/docs/api-reference?lang=python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fa57eb3b-7635-4ab6-8330-3eab189cc331",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:05:50.278488Z",
+     "iopub.status.busy": "2023-02-24T07:05:50.278311Z",
+     "iopub.status.idle": "2023-02-24T07:05:50.280680Z",
+     "shell.execute_reply": "2023-02-24T07:05:50.280215Z",
+     "shell.execute_reply.started": "2023-02-24T07:05:50.278471Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import openai\n",
+    "# help(openai)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce72abaa-95ec-489d-a553-b3d2e469f645",
+   "metadata": {},
+   "source": [
+    "### Now the most important string in this code is your API key ! Please don't keep it open\n",
+    "\n",
+    "For future scenarios I would suggest to store it in a config file or in your env. Temporarily for testing, it could be used as a string. \n",
+    "\n",
+    "How to generate API KEY for first time user? \n",
+    "\n",
+    "https://platform.openai.com/account/api-keyshttps://platform.openai.com/account/api-keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f5c3d709-0bd1-4324-aea5-d19de2012d7d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:05:51.108196Z",
+     "iopub.status.busy": "2023-02-24T07:05:51.107818Z",
+     "iopub.status.idle": "2023-02-24T07:05:52.459949Z",
+     "shell.execute_reply": "2023-02-24T07:05:52.459617Z",
+     "shell.execute_reply.started": "2023-02-24T07:05:51.108179Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# you could set it in your local env using EXPORT OPENAI_API_KEY=<key value>\n",
+    "\n",
+    "import os\n",
+    "import openai\n",
+    "openai.organization = \"org-devesh\"\n",
+    "openai.api_key = os.getenv(\"OPENAI_API_KEY\")\n",
+    "\n",
+    "openai.api_key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1a329baf-d8c6-4308-853d-dc5f77267aa4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:05:52.461056Z",
+     "iopub.status.busy": "2023-02-24T07:05:52.460942Z",
+     "iopub.status.idle": "2023-02-24T07:05:52.463905Z",
+     "shell.execute_reply": "2023-02-24T07:05:52.463445Z",
+     "shell.execute_reply.started": "2023-02-24T07:05:52.461044Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# OR Can set it if you are testing out functionality but not recommended\n",
+    "\n",
+    "openai.api_key=\"<Paste key>\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cc1725d-dfc9-4483-8238-24707dbea0b4",
+   "metadata": {},
+   "source": [
+    "#### Here we write our function which converts text prompt to image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e8387c91-00c8-44ed-ae69-ac34c37b8544",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:05:54.265322Z",
+     "iopub.status.busy": "2023-02-24T07:05:54.265145Z",
+     "iopub.status.idle": "2023-02-24T07:05:54.270604Z",
+     "shell.execute_reply": "2023-02-24T07:05:54.270072Z",
+     "shell.execute_reply.started": "2023-02-24T07:05:54.265304Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "import requests\n",
+    "from requests.structures import CaseInsensitiveDict\n",
+    "import json\n",
+    "\n",
+    "def generate_image(prompt):\n",
+    "    # Print the prompt to the console\n",
+    "    print(prompt)\n",
+    "    \n",
+    "    # Remove non-alphanumeric characters from the tweet using regular expressions\n",
+    "    prompt = re.sub(r'[^\\w\\s]+', '', prompt)\n",
+    "    \n",
+    "    # Print the cleaned-up prompt to the console\n",
+    "    print(prompt)\n",
+    "    \n",
+    "    # Set the API endpoint URL\n",
+    "    url = \"https://api.openai.com/v1/images/generations\"\n",
+    "    \n",
+    "    # Set the request headers, including the API key for authentication\n",
+    "    headers = CaseInsensitiveDict()\n",
+    "    headers[\"Content-Type\"] = \"application/json\"\n",
+    "    headers[\"Authorization\"] = f\"Bearer {openai.api_key}\"\n",
+    "\n",
+    "    # Set the request payload data as a JSON-formatted string\n",
+    "    data = \"\"\"\n",
+    "    {\n",
+    "        \"\"\"\n",
+    "    data += f'\"model\": \"image-alpha-001\",'\n",
+    "    data += f'\"prompt\": \"{prompt}\",'\n",
+    "    data += \"\"\"\n",
+    "        \"num_images\":1,\n",
+    "        \"size\":\"512x512\",\n",
+    "        \"response_format\":\"url\"\n",
+    "    }\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # Send a POST request to the OpenAI API to generate an image\n",
+    "    resp = requests.post(url, headers=headers, data=data)\n",
+    "\n",
+    "    # If the response status code is not 200 (OK), raise a ValueError with an error message\n",
+    "    if resp.status_code != 200:\n",
+    "        print(resp.text)\n",
+    "        raise ValueError(\"Failed to generate image\")\n",
+    "\n",
+    "    # Parse the response JSON and return the URL of the generated image\n",
+    "    response_text = resp.text\n",
+    "    response_json = json.loads(response_text)\n",
+    "    return response_json['data'][0]['url']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ed057b48-bc47-41e7-95c0-0160fcbb6dfb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:06:10.084659Z",
+     "iopub.status.busy": "2023-02-24T07:06:10.084482Z",
+     "iopub.status.idle": "2023-02-24T07:06:10.088275Z",
+     "shell.execute_reply": "2023-02-24T07:06:10.087244Z",
+     "shell.execute_reply.started": "2023-02-24T07:06:10.084642Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "prompt = \"Arjun warrior. Long shot.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c307027-dc3e-44ad-9c5e-4417e88411b9",
+   "metadata": {},
+   "source": [
+    "#### Here, I've written a code to embed the image in Jupyter. We could modify it for downloading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bacd7fd2-4915-4f7e-b019-f8c5146898b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:06:10.674642Z",
+     "iopub.status.busy": "2023-02-24T07:06:10.674477Z",
+     "iopub.status.idle": "2023-02-24T07:06:16.147368Z",
+     "shell.execute_reply": "2023-02-24T07:06:16.146977Z",
+     "shell.execute_reply.started": "2023-02-24T07:06:10.674625Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Arjun warrior. Long shot.\n",
+      "Arjun warrior Long shot\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<img src=\"https://oaidalleapiprodscus.blob.core.windows.net/private/org-ewlSySEuzn6HLUcfwHoUTsBH/user-vVJ8Nyg9LE5hZgaVGOsDtzIe/img-eYOskBFn2gIsqvrvHXufu5O8.png?st=2023-02-24T06%3A06%3A16Z&se=2023-02-24T08%3A06%3A16Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2023-02-24T00%3A11%3A40Z&ske=2023-02-25T00%3A11%3A40Z&sks=b&skv=2021-08-06&sig=MreJVbdlKpw3r8ZBLtRdLqMGLuC5gNKOFmbDUHkGcIY%3D\"/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import Image\n",
+    "\n",
+    "# Generate the URL for the image\n",
+    "image_url = generate_image(prompt)\n",
+    "\n",
+    "# Embed the image in the notebook\n",
+    "Image(url=image_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80517e0d-1f03-4a61-a3d3-6480609b72f3",
+   "metadata": {},
+   "source": [
+    "#### Great, we got an output. Are we done ? No. Here's what we try out now. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7c7c946-a68e-4a6b-ba45-06d044547f4b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:09:06.363730Z",
+     "iopub.status.busy": "2023-02-24T07:09:06.363404Z",
+     "iopub.status.idle": "2023-02-24T07:09:06.380516Z",
+     "shell.execute_reply": "2023-02-24T07:09:06.378346Z",
+     "shell.execute_reply.started": "2023-02-24T07:09:06.363711Z"
+    },
+    "tags": []
+   },
+   "source": [
+    "* These are the prompts that professor gave us. Let's try randomly adding them. *\n",
+    "\n",
+    "Styles\n",
+    "\n",
+    "Abstract, Abstract Organic, Afrofuturism, Airbrush, Alegria, Ancient Art, Ancient Egyptian Art, Anime, Art Deco, Art Nouveau, Babylonian Art, Baroque, Biopunk, Chinese Watercolor, Constructivism, Cubism, Cybernetic, Cyberpunk, Dadaism, Dieselpunk, Expressionism, Fauvism, Fractal, Futurism, Glitchcore, Gothic, Hieroglyphics, Impressionist, Low Poly, Mannerism, Medieval Art, Mexican Muralism, Minimalism, Neoclassicism, Photorealism, Pointillism, Pop Art, Post-apocalyptic, Post-impressionism, Prehistoric Art, Realism, Renaissance, Rococo, Romanticism, Skeumorphism, Steampunk, Suminagashi, Suprematism, Surrealism, Symbolism, Synthwave, Vaporwave\n",
+    "\n",
+    "Artists\n",
+    "\n",
+    "Wes Anderson, Arcimboldo, Pierre Auguste Renoir, Banksy, Hanna Barbera, Basquiat, Zdzislaw Beksinski, Albert Bierstadt, Hieronymus Bosch, Georges Braque, Duffer Brothers, Pieter Brueghel, Caravaggio, Thomas Cole, John Constable, Dean Cornwell, Leonardo Da Vinci, Salvador Dali, Samuel Daniell, Gustave Dore, Gustave Doré, Mc Escher, Lisa Frank, Frank Frazetta, Lucian Freud, Galen, Frank Gehry, Francisco Goya, James Gurney, Robert Hargreaves, Keith Haring, Katsushika Hokusai, Edward Hopper, Frida Kahlo, Thomas Kinkaid, Utagawa Kuniyoshi, Dorothea Lange, Annie Leibovitz, Saul Leiter, Roy Lichtenstein, Claude Lorrain, René Magritte, Henri Matisse, Robert Mccall, Ralph Mcquarrie, Michelangelo, Hatsune Miku, Hayao Miyazaki, Piet Mondrian, Claude Monet, Alphonse Mucha, Craig Mullins, Edvard Munch, Pablo Picasso, Jackson Pollock, Beatrix Potter, Terry Richardson, Diego Rivera, Norman Rockwell, Mark Rothko, Greg Rutkowski, Axel Schaefer, Georges Seurat, Yoji Shinkawa, Ivan Shishkin, Simon Stålenhag, Brueghel The Elder, Vincent Van Gogh, Johannes Vermeer, Andy Warhol, Bill Watterson, Toshi Yoshid\n",
+    "\n",
+    "Formats\n",
+    "\n",
+    "3d Render, Action Photography, Advertising Campaign, Advertising Poster, Album Art Cover, Ancient Egypt Papyrus, Aquatint Print, Architectural Photography From Magazine, Autochrome, Aztec Carving, Blueprint, Book Cover, Bronze Statue, Byzantine Icon, Camera Obscura, Cartoon, Cave Painting, Cgi, Charcoal Drawing, Cinematography From Music Video, Claymation, Collage, Colouring-in Sheet, Comic Book Art, Courtroom Sketch, Crayon Drawing, Dashcam, Decorative Minoan Mural, Diagram, Disposable Camera, Double Exposure, Editorial Fashion Photography, Experimental Expired Film Photo, Fifth Grade Yearbook, Full Body Photo, Harsh Flash Photography, Houdini 3d Render, Ice Carving, Illustration, Instruction Manual, Interior Design, Kindergartener Drawing, Layered Paper, Line Art, Line Drawing, Linocut, Lomography, Long-exposure Photograph With Slow Shutter Speed, Low Poly, Macro 35mm Photograph, Manuscripts, Marble Statue, Medieval Portrait, Modeling Photoshoot, Mugshot, Mythological Map, Oil Painting, One-line Drawing, Origami, Painting, Pastel Drawing, Patent Drawing, Pencil And Watercolor Drawing, Pencil Sketch, Photograph, Photoshopped Image, Pinhole Photography, Pirate Map, Pixel Art, Polaroid, Portrait, Press Release, Product Photography, Professional Corporate Portrait, Real Estate Photography, Roman Mosaic, Selfie, Shot On Iphone 11, Sigma 75mm, Sketchbook, Spray-painted Onto A Wall, Stained Glass Window, Sticker Illustration, Stop-motion Animation, Storybook, Street Art, Studio Photography, Tattoo, Terracotta Warriors, Theatrical Press Release, Topiary, Trail Cam, Travel Photography, Under Electron Microscope, Vector Art, Voynich Manuscript, Watercolor Painting, \n",
+    "\n",
+    "Boosters\n",
+    "\n",
+    "#wow, 4k, 4k Resolution, 70mm, 8k, Arnold Render, Beautiful, Blender 3d, Contest Winner, Detailed, Digital Art, Extremely Detailed, Fantastic, High Detail, High Poly, Highly Detailed, Hyper Realistic, Hyperrealistic, Octane Render, Photorealistic, Postprocessing, Professional, Rendered In Unreal Engine, Rendering, Studio Lighting, Stunning, Trending On Artstation, Ultra High Poly, Unreal Engine, Very Beautiful, Vfx, Vivid, Well Preserved, Wondrous, Vibes, Perspectives, Inspire\n",
+    "\n",
+    "Vibes\n",
+    "\n",
+    "Amorphous, Atmospheric, Awesome, Awestruck, Blur, Bold, Brash, Bright, Character, Charming, Cinematic, Colorful, Concept Art, Control The Soul, Cosmos, Crystal, Curvaceous, Cute, Dark, Distortion, Dust, Dystopian, Eclectic, Elegant, Emo, Emotive, Epic, Ethereal, Extemporaneous, Eyes Wide In Wonder, Faded, Fantasy, Funereal, Furry, Futuristic, Ghastly, Gorgeous, Grainy, Hairy, Intricately Designed, Jaunty, Kaleidoscopic, Lucid, Made Of Yarn, Magical, Magnificent, Manmade, Melancholic, Melancholy, Metallic, Monumental, Moody, Muted, Mysterious, Neon, Old, Ominous, Opaque, Particulate, Peaceful, Psychedelic, Reflection, Refraction, Retrofuturistic, Saturated, Scenic, Serene, Smears, Smoke Effect, Smudges, Spirited, Spontaneous, Stormy, Tasteful, Tender, Transhumanist, Unnerving, Uplight, Utopian, Wormhole, ✨, Perspectives, Inspire\n",
+    "\n",
+    "Perspectives\n",
+    "\n",
+    "85mm, Aerial View, Bokeh, Close Face, Close Up, Dark Background, Drone, Extreme Close-up Shot, Extreme Wide Shot, Fisheye Lens, Framed, From Above, From Behind, From Below, Full Shot, Hard Lighting, Head-and-shoulders Shot, In The Distance, Isometric, Landscape, Lens Flare, Long Shot, Low Angle, Midshot, Motion Blur, On Canvas, Over-the-shoulder Shot, Overhead View, Oversaturated Filter, Panoramic, Plain Background, Shallow Depth Of Field, Sunset Photo At Golden Hour, Telephoto, Through A Periscope, Through A Porthole, Tilted Frame, Viewed From Behind, White Background, Wide Angle\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33a9796d-a7cb-444e-939f-d922346b0ddc",
+   "metadata": {},
+   "source": [
+    "### Our long term goal here is to essentially figure out the language of Dall-e. How to communicate with the bot to get exactly an output which we like.\n",
+    "\n",
+    "**So How do we do it ?**\n",
+    "\n",
+    "Well, we start by trying out if a functionality works or not on a specific subject.  \n",
+    "Let's take an example here.\n",
+    "\n",
+    "Let the subject be the warrior Arjun from the Indian Epic Mahabharata. \n",
+    "\n",
+    "Now, let's say we want a hyper realistic picture which is zoomed out. \n",
+    "\n",
+    "Could you figure out a prompt for the same. If you can, just write it all down in an article.  \n",
+    "\n",
+    "Here's Prof Nick Brown's for reference : \n",
+    "https://medium.com/@NikBearBrown/ai-skunkworks-the-dall-e-scale-parameter-with-mutant-ninja-turtles-3b221ec99d54\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2af7867-fc20-4535-b1eb-ca9375fa93e7",
+   "metadata": {},
+   "source": [
+    "#### Sample Usecase : Figure out a keyword which, when added to our prompt will not result in these edges being cutout.\n",
+    "\n",
+    "So here, we have tried the following :\n",
+    "\n",
+    "1. Arjun Warrior.\n",
+    "2. Arjun Warrior. Zoomed out\n",
+    "3. Arjun Warrior. Long shot\n",
+    "4. Arjun Warrior. Make it smaller.\n",
+    "5. Arjun Warrior. Standing on ground.\n",
+    "6. Arjun Warrior. Standing on ground. Full body\n",
+    "\n",
+    "But none of them seem to work. Say, you solve one such usecase. Then what ? Write about it ! \n",
+    "And add your code to the Dall-e folder in botspeak. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fcf0a65f-adbb-42a5-b240-2124a26bb88c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2023-02-24T07:17:01.571551Z",
+     "iopub.status.busy": "2023-02-24T07:17:01.571373Z",
+     "iopub.status.idle": "2023-02-24T07:17:07.166480Z",
+     "shell.execute_reply": "2023-02-24T07:17:07.166033Z",
+     "shell.execute_reply.started": "2023-02-24T07:17:01.571533Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Arjun warrior. Hyper realistic. standing on ground. full body\n",
+      "Arjun warrior Hyper realistic standing on ground full body\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<img src=\"https://oaidalleapiprodscus.blob.core.windows.net/private/org-ewlSySEuzn6HLUcfwHoUTsBH/user-vVJ8Nyg9LE5hZgaVGOsDtzIe/img-LE4TSaQgWrIVnOgLMw2qip7n.png?st=2023-02-24T06%3A17%3A07Z&se=2023-02-24T08%3A17%3A07Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2023-02-23T20%3A34%3A26Z&ske=2023-02-24T20%3A34%3A26Z&sks=b&skv=2021-08-06&sig=gea4mypo/QCmJgxs74Uq0EggYvKSuZak9ZDSVQierJY%3D\"/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prompt = \"Arjun warrior. Hyper realistic. standing on ground. full body\"\n",
+    "\n",
+    "from IPython.display import Image\n",
+    "\n",
+    "# Generate the URL for the image\n",
+    "image_url = generate_image(prompt)\n",
+    "\n",
+    "# Embed the image in the notebook\n",
+    "Image(url=image_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c86c847-69d1-4fe6-b037-ef838649001d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "877b5462-e39f-4aa9-baf7-1825049763b9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Have added a simple notebook demostrating use of python client of open api. How to create key. Convert text prompt to image using openai and dalle. Also have added a sample usecase for people to refer, professor's tag suggestions to work on as well as medium article links in notebook. Requesting review.